### PR TITLE
Added file extensions .t3s and .typoscript

### DIFF
--- a/grammars/typoscript.cson
+++ b/grammars/typoscript.cson
@@ -2,7 +2,9 @@
 'scopeName': 'source.typoscript'
 'fileTypes': [
   'ts'
+  't3s'
   'txt'
+  'typoscript'
 ]
 'foldingStartMarker': '/\\*\\*|\\{\\s*$'
 'foldingStopMarker': '\\*\\*/|^\\s*\\}'


### PR DESCRIPTION
I have seen several people preferring these extensions, as they help to distinguish typoscript files from typescript.